### PR TITLE
initial draft of binder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TikhonovTutorial
-Originally given as a tutorial at NeuroHackademy 2020 by Alex Huth.
+Originally given as a tutorial at NeuroHackademy 2020 by Alex Huth. [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/alexhuth/tikhonovtutorial/master)
 
 In this tutorial you'll learn about three different linear regression methods: ordinary least squares, ridge regression, and Tikhonov regression. The tutorial explores these methods both theoretically and practically, since each is used to fit encoding models that predict fMRI responses to natural language stimuli.
 
@@ -18,10 +18,26 @@ The analysis demonstrated in this tutorial forms the basis of these two papers:
 
 Getting Started
 ---------------
+There are two ways you can run this tutorial. If you want to go through the materials on your own machine, please follow the instructions below:
+
+_On Linux_
+
 1. (If not using Anaconda) install dependencies:
 `sudo apt-get update`
 `sudo apt-get install -y ipython ipython-notebook python-numpy python-scipy python-matplotlib cython python-pip python-pip python-dev python-h5py python-nibabel python-lxml python-shapely python-html5lib python-tables git pycortex`
 2. Start a Jupyter notebook server in this directory (if you don't already have one):
 `jupyter notebook`
+
+OR
+
+1. `git clone https://github.com/alexhuth/TikhonovTutorial`
+2. `cd TikhonovTutorial`
+3. `pip install -r requirements.txt`
+4. `jupyter notebook`
+
+
+If you want to run it interactively in your browser without the necessity to install the dependencies, please check this binder instance:
+
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/alexhuth/tikhonovtutorial/master)
 
 The necessary fMRI data will be downloaded and unarchived in the first tutorial notebook, so make sure you run that before the others!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+numpy
+matplotlib
+scipy
+cython
+h5py
+nibabel
+lxml
+shapely
+html5lib
+tables
+pycortex
+jupyter


### PR DESCRIPTION
This PR adds an initial draft to support a binder instance of the tutorial.  In more detail it adds a `requirements.txt` file and install/run instructions to the `README`.